### PR TITLE
:penguin: Paths on Linux are case sensitive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,8 @@ IF (APPLE) # Mac OSX
 ENDIF (APPLE)
 
 # Add the virtual computer
+SET(BUILD_STATIC_VCOMPUTER TRUE CACHE BOOL "Build Trillek VCOMPUTER library - static
+     version")
 SET(BUILD_DYNAMIC_VCOMPUTER FALSE CACHE BOOL "Build Trillek VCOMPUTER library - dynamic version")
 SET(BUILD_TOOLS_VCOMPUTER FALSE CACHE BOOL "Build Trillek VCOMPUTER tools")
 SET(BUILD_TESTS_VCOMPUTER FALSE CACHE BOOL "Build Trillek VCOMPUTER tests")

--- a/include/vcomputer-system.hpp
+++ b/include/vcomputer-system.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "VComputer.hpp"
+#include "vcomputer.hpp"
 #include "types.hpp"
 #include <memory>
 #include <list>
 #include <cstdint>
 #include "resources/pixel-buffer.hpp"
-#include "devices/TDA.hpp"
-#include "devices/GKeyb.hpp"
+#include "devices/tda.hpp"
+#include "devices/gkeyb.hpp"
 
 #include "event-system.hpp"
 #include "command-queue.hpp"

--- a/src/vcomputer-system.cpp
+++ b/src/vcomputer-system.cpp
@@ -2,9 +2,9 @@
 #include "os.hpp"
 #include "entity.hpp"
 
-#include "VComputer.hpp"
-#include "Auxiliar.hpp"
-#include "TR3200/TR3200.hpp"
+#include "vcomputer.hpp"
+#include "auxiliar.hpp"
+#include "tr3200/tr3200.hpp"
 
 #include "graphics/texture-object.hpp"
 


### PR DESCRIPTION
Also, enforces Static version of virtual computer
